### PR TITLE
Add Spanish translations for body content

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -26,6 +26,20 @@
         class="w3-bar-item w3-button w3-hide-small w3-padding-large w3-hover-white"
         >Donate</a
       >
+      <nuxt-link
+        v-if="$i18n.locale != 'es'"
+        :to="switchLocalePath('es')"
+        class="w3-bar-item w3-button w3-hide-small w3-padding-large w3-hover-white w3-right"
+      >
+        Español
+      </nuxt-link>
+      <nuxt-link
+        v-if="$i18n.locale != 'en'"
+        :to="switchLocalePath('en')"
+        class="w3-bar-item w3-button w3-hide-small w3-padding-large w3-hover-white w3-right"
+      >
+        English
+      </nuxt-link>
     </div>
 
     <div
@@ -41,6 +55,20 @@
         class="w3-bar-item w3-button w3-padding-large"
         >Donate</a
       >
+      <nuxt-link
+        v-if="$i18n.locale != 'es'"
+        :to="switchLocalePath('es')"
+        class="w3-bar-item w3-button w3-padding-large"
+      >
+        Español
+      </nuxt-link>
+      <nuxt-link
+        v-if="$i18n.locale != 'en'"
+        :to="switchLocalePath('en')"
+        class="w3-bar-item w3-button w3-padding-large"
+      >
+        English
+      </nuxt-link>
     </div>
   </div>
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -6,6 +6,14 @@
   </div>
 </template>
 
+<script>
+export default {
+  head() {
+    return this.$nuxtI18nHead({ addSeoAttributes: true })
+  },
+}
+</script>
+
 <style>
 body,
 h1,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -12,9 +12,7 @@ export default {
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
     title: meta.title,
-    htmlAttrs: {
-      lang: 'en',
-    },
+    htmlAttrs: {},
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
@@ -103,7 +101,7 @@ export default {
   i18n: {
     locales: [
       { code: 'en', iso: 'en-US', dir: 'ltr' },
-      { code: 'es', iso: 'es', dir: 'ltr' },
+      { code: 'es', iso: 'es-ES', dir: 'ltr' },
     ],
     defaultLocale: 'en',
     langDir: '~/locales/',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -102,13 +102,14 @@ export default {
 
   i18n: {
     locales: [
-      { code: 'en', iso: 'en-US', file: 'en.js', dir: 'ltr' },
-      { code: 'es', iso: 'es', file: 'es.js', dir: 'ltr' },
+      { code: 'en', iso: 'en-US', dir: 'ltr' },
+      { code: 'es', iso: 'es', dir: 'ltr' },
     ],
     defaultLocale: 'en',
     langDir: '~/locales/',
     vueI18n: {
       fallbackLocale: 'en',
     },
+    vueI18nLoader: true,
   },
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -95,8 +95,20 @@ export default {
   ],
 
   // Modules: https://go.nuxtjs.dev/config-modules
-  modules: [],
+  modules: ['nuxt-i18n'],
 
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {},
+
+  i18n: {
+    locales: [
+      { code: 'en', iso: 'en-US', file: 'en.js', dir: 'ltr' },
+      { code: 'es', iso: 'es', file: 'es.js', dir: 'ltr' },
+    ],
+    defaultLocale: 'en',
+    langDir: '~/locales/',
+    vueI18n: {
+      fallbackLocale: 'en',
+    },
+  },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1074,6 +1074,29 @@
         }
       }
     },
+    "@intlify/shared": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.0.0.tgz",
+      "integrity": "sha512-0r4v7dnY8g/Jfx2swUWy2GyfH/WvIpWvkU4OIupvxDTWiE8RhcpbOCVvqpVh/xGi0proHQ/r2Dhc0QSItUsfDQ=="
+    },
+    "@intlify/vue-i18n-extensions": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-i18n-extensions/-/vue-i18n-extensions-1.0.2.tgz",
+      "integrity": "sha512-rnfA0ScyBXyp9xsSD4EAMGeOh1yv/AE7fhqdAdSOr5X8N39azz257umfRtzNT9sHXAKSSzpCVhIbMAkp5c/gjQ==",
+      "requires": {
+        "@babel/parser": "^7.9.6"
+      }
+    },
+    "@intlify/vue-i18n-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-i18n-loader/-/vue-i18n-loader-1.1.0.tgz",
+      "integrity": "sha512-9LXiztMtYKTE8t/hRwwGUp+ofrwU0sxLQLzFEOZ38zvn0DonUIQmZUj1cfz5p1Lu8BllxKbCrn6HnsRJ+LYA6g==",
+      "requires": {
+        "@intlify/shared": "^9.0.0",
+        "js-yaml": "^3.13.1",
+        "json5": "^2.1.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -6660,6 +6683,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-https": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-https/-/is-https-3.0.2.tgz",
+      "integrity": "sha512-jFgAKhbNF7J+lTMJxbq5z9bf1V9f8rXn9mP5RSY2GUEW5M0nOiVhVC9dNra96hQDjGpNzskIzusUnXwngqmhAA=="
+    },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -6809,6 +6837,11 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.6.4.tgz",
       "integrity": "sha512-ICUtP0/rAyT/GaaDG0vj6fmWzx5yjFc7v+L1MAEARGl1+lrdJ8wtJNChr+ZGEdPoOhFwdhtcDO5VM2TNNgPpjQ=="
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6871,6 +6904,11 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
+    "klona": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
     },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
@@ -7012,6 +7050,11 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -7597,6 +7640,32 @@
         "@nuxt/vue-app": "2.15.3",
         "@nuxt/vue-renderer": "2.15.3",
         "@nuxt/webpack": "2.15.3"
+      }
+    },
+    "nuxt-i18n": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/nuxt-i18n/-/nuxt-i18n-6.22.3.tgz",
+      "integrity": "sha512-IZ4OLOYHsF6cKB0ik7j9rFr81xFmij/HQNgepcc63dFJFU6SSHJ6uO2RkGo7v8e0ttr9QDIiTM3xJrmd5W1PVQ==",
+      "requires": {
+        "@babel/parser": "^7.5.5",
+        "@babel/traverse": "^7.5.5",
+        "@intlify/vue-i18n-extensions": "^1.0.1",
+        "@intlify/vue-i18n-loader": "^1.0.0",
+        "cookie": "^0.4.0",
+        "devalue": "^2.0.1",
+        "is-https": "^3.0.0",
+        "js-cookie": "^2.2.1",
+        "klona": "^2.0.4",
+        "lodash.merge": "^4.6.2",
+        "ufo": "^0.6.7",
+        "vue-i18n": "^8.23.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
       }
     },
     "object-assign": {
@@ -11065,6 +11134,11 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
+    },
+    "vue-i18n": {
+      "version": "8.24.2",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.24.2.tgz",
+      "integrity": "sha512-+TkAPBQw4Cp2bQrSPtPNkhET7XcWYjjDt1UjWYQs+xbT41q5OAl1I3IZyhg0drjn1nlC1K0f8sLVB/nshUcF1Q=="
     },
     "vue-loader": {
       "version": "15.9.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "core-js": "^3.9.1",
-    "nuxt": "^2.15.3"
+    "nuxt": "^2.15.3",
+    "nuxt-i18n": "^6.22.3"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config": "^6.0.0",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,15 +4,9 @@
     <div id="faq" class="w3-row-padding w3-padding-32 w3-container">
       <div class="w3-content">
         <div class="w3-twothird">
-          <h1>It's time for single-payer in California.</h1>
+          <h1>{{ $t('section-intro.header') }}</h1>
           <h5 class="w3-padding-32" style="padding-left: 0px !important">
-            The US healthcare system is designed to maximize profit, not patient
-            care. Millions of working-class Americans have lost their health
-            insurance during the COVID-19 pandemic; meanwhile, California's 165
-            billionaires have seen their wealth increase by $175,000,000,000
-            since March. In the richest state in the richest country in the
-            world, this is unacceptable. We can and we must pass Medicare for
-            All—and that starts here in California.
+            {{ $t('section-intro.body') }}
           </h5>
         </div>
 
@@ -40,15 +34,9 @@
         </div>
 
         <div class="w3-twothird">
-          <h1>What is AB1400?</h1>
+          <h1>{{ $t('section-ab1400.header') }}</h1>
           <h5 class="w3-padding-32" style="padding-left: 0px !important">
-            Assembly Bill 1400 (AB1400) would create the California Guaranteed
-            Health Care for All program, or CalCare, to provide comprehensive
-            universal single-payer health care coverage for the benefit of all
-            residents of the state. Authored by State Assembly member Ash Kalra,
-            AB1400 would expand coverage to nearly 3 million uninsired
-            Californians and provide rich benefits, including dental care,
-            generous prescription drug coverage and long-term care.
+            {{ $t('section-ab1400.body') }}
           </h5>
         </div>
       </div>
@@ -58,16 +46,9 @@
     <div class="w3-row-padding w3-padding-32 w3-container">
       <div class="w3-content">
         <div class="w3-twothird">
-          <h1>Who are the Democratic Socialists of America?</h1>
+          <h1>{{ $t('section-dsa.header') }}</h1>
           <h5 class="w3-padding-32" style="padding-left: 0px !important">
-            The Democratic Socialists of America is the largest socialist
-            organization in the United States, with over 92,000 members and
-            chapters in all 50 states. We believe that working people should run
-            both the economy and society democratically to meet human needs, not
-            to make profits for a few. We are a political and activist
-            organization, not a party; through campus and community-based
-            chapters, DSA members use a variety of tactics, from legislative to
-            direct action, to fight for reforms that empower working people.
+            {{ $t('section-dsa.body') }}
           </h5>
         </div>
 
@@ -141,3 +122,75 @@
   margin-right: auto;
 }
 </style>
+
+<i18n lang="yaml">
+en:
+  section-intro:
+    header: It's time for single-payer in California.
+    body: |
+      The US healthcare system is designed to maximize profit, not patient
+      care. Millions of working-class Americans have lost their health
+      insurance during the COVID-19 pandemic; meanwhile, Californias 165
+      billionaires have seen their wealth increase by $175,000,000,000 since
+      March. In the richest state in the richest country in the world, this
+      is unacceptable. We can and we must pass Medicare for All—and that
+      starts here in California.
+  section-ab1400:
+    header: What is AB1400?
+    body: |
+      Assembly Bill 1400 (AB1400) would create the California Guaranteed
+      Health Care for All program, or CalCare, to provide comprehensive
+      universal single-payer health care coverage for the benefit of all
+      residents of the state. Authored by State Assembly member Ash Kalra,
+      AB1400 would expand coverage to nearly 3 million uninsired Californians
+      and provide rich benefits, including dental care, generous prescription
+      drug coverage and long-term care.
+  section-dsa:
+    header: Who are the Democratic Socialists of America?
+    body: |
+      The Democratic Socialists of America is the largest socialist
+      organization in the United States, with over 92,000 members and
+      chapters in all 50 states. We believe that working people should run
+      both the economy and society democratically to meet human needs, not to
+      make profits for a few. We are a political and activist organization,
+      not a party; through campus and community-based chapters, DSA members
+      use a variety of tactics, from legislative to direct action, to fight
+      for reforms that empower working people.
+es:
+  section-intro:
+    header: Es hora para un sistema de Medicare para Todos en California.
+    body: |
+      El sistema de salud de los Estados Unidos está diseñado para maximizar
+      las ganancias de las empresas de aseguranza, no la atención al
+      paciente. Millones de estadounidenses de clase trabajadora han perdido
+      su seguro médico durante la pandemia de COVID-19; mientras tanto, los
+      165 multimillonarios de California han visto aumentar su riqueza en
+      $175,000,000,000 desde marzo de 2020. En el estado más rico del país,
+      más rico del mundo, esto es inaceptable. Podemos y debemos aprobar
+      Medicare para Todos, y eso comienza aquí en California.
+  section-ab1400:
+    header: ¿Qué es AB 1400?
+    body: |
+      El proyecto de ley de la asamblea número 1400 (AB 1400) crearía el
+      programa Tratamiento Médico Garantizado para Todos en California, o
+      CalCare, o Medicare para Todos, para brindar una aseguranza integral de
+      atención médica universal de pagador único (o sea, sin aseguranza
+      privada) a beneficio de todos los residentes del estado. Escrito por el
+      miembro de la Asamblea Estatal Ash Kalra, AB 1400 ampliaría la
+      aseguranza a casi 3 millones de californianos no asegurados y brindaría
+      importantes beneficios nuevos, que incluyen atención dental, generosa
+      cobertura de recetas médicas y cuidado a largo plazo.
+  section-dsa:
+    header: ¿Quiénes son los socialistas democráticos de América?
+    body: |
+      Los Socialistas Democráticos de América (DAS) es la organización
+      socialista más grande de los Estados Unidos, con más de 92.000 miembros
+      y capítulos en los 50 estados. Creemos que los trabajadores deben
+      administrar la economía y la sociedad de manera democrática para
+      satisfacer las necesidades humanas, no para obtener ganancias para unos
+      pocos. Somos una organización política y activista, no un partido. A
+      través de capítulos basados en los colegios y la comunidad, los
+      miembros de la DSA utilizan una variedad de tácticas, desde la acción
+      legislativa hasta la acción directa, para luchar por reformas que den
+      poder a los trabajadores.
+</i18n>


### PR DESCRIPTION
Adds Spanish translations, viewable at `/es`. If the browser language is configured, users will be redirected automatically. ~I'll open a separate PR for the language switcher.~ *Edit*: language switcher didn't take much code so I included it here. Let me know what you think.

I included the translations for this directly in the page because they'll only be used on this page. We can add global translations to locale files.